### PR TITLE
A couple of tweaks to the faucet prior to launch

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -11,14 +11,14 @@
     
     <meta property="og:title" content="Faucet for the Avalanche Testnet">
     <meta property="og:site_name" content="Faucet | Avalanche">
-    <meta property="og:url" content="https://faucet.avax-test.network/">
+    <meta property="og:url" content="https://faucet.avax.network/">
     <meta property="og:description" content="Avalanche Faucet is a place where you can get free test tokens to play with, on the Avalanche's Fuji Network and other Subnets">
     <meta property="og:type" content="website">
 
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <title>Faucet | Avalanche</title>
   </head>
-  <body style="background-color: #000000; background-image: linear-gradient(315deg, #000000 0%, #414141 100%);">
+  <body style="background: no-repeat center center fixed; background-image: linear-gradient(315deg, #000000 0%, #414141 100%);">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
   </body>

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -5,3 +5,10 @@
     justify-content: space-around;
     align-items: center;
 }
+
+@media screen and (max-width: 1010px) {
+    .app {
+        padding-top: 10%;
+        padding-bottom: 10%;
+    }
+}

--- a/client/src/components/AddNetwork.tsx
+++ b/client/src/components/AddNetwork.tsx
@@ -37,7 +37,7 @@ export default function AddNetwork(props: any) {
         <div className='footer-buttons'>
             <button className="add-network" onClick={() => {addNetwork(props.config)}}>
                 <img style={{width: "25px", height: "25px", marginRight: "5px"}} src="/memtamask.png"/>
-                Add Chain to Metamask
+                Add Subnet to Metamask
             </button>
 
             <button className="add-network" onClick={() => {window.open(`${props.config.EXPLORER}`, '_blank')}}>

--- a/client/src/components/Contribute.tsx
+++ b/client/src/components/Contribute.tsx
@@ -1,9 +1,16 @@
+import { useState, useEffect } from 'react'; 
 import './styles/Contribute.css'
 
 const Contribute = () => {
+    const [hiddenClass, setHiddenClass] = useState('')
+
+    setTimeout(() => {
+        setHiddenClass("hide-button")
+    }, 2000);
+
     return (
-        <div className="contribute-button" onClick={() => {window.open('https://github.com/ava-labs/avalanche-faucet', '_blank')}}>
-            <img style={{width: "25px", height: "25px", marginRight: "10px"}} src="/github.png"/>
+        <div className={`contribute-button ${hiddenClass}`} onClick={() => {window.open('https://github.com/ava-labs/avalanche-faucet', '_blank')}}>
+            <img src="/github.png"/>
             Contribute on Github
         </div>
     )

--- a/client/src/components/FaucetForm.tsx
+++ b/client/src/components/FaucetForm.tsx
@@ -70,8 +70,8 @@ const FaucetForm = (props: any) => {
             updateAddress(query?.address);
         }
 
-        if(typeof query?.chain == "string") {
-            setChain(chainToIndex(query.chain))
+        if(typeof query?.subnet == "string") {
+            setChain(chainToIndex(query.subnet))
         } else {
             setChain(0)
         }

--- a/client/src/components/FooterBox.tsx
+++ b/client/src/components/FooterBox.tsx
@@ -24,7 +24,7 @@ export default function FooterBox(props: any) {
             <div className="footer-box">
                 <div style={{fontSize: "13px", padding: "20px"}}>
                     Use the buttons below to add <b>{props.chainConfigs[props.chain!]?.NAME}</b> to your browser wallet extension
-                    or visit the chain's block explorer.
+                    or visit the Subnet's block explorer.
                     <AddNetwork config={props.chainConfigs[props.chain!]}/>
                 </div>
             </div>

--- a/client/src/components/styles/Contribute.css
+++ b/client/src/components/styles/Contribute.css
@@ -1,5 +1,5 @@
 .contribute-button {
-    position: absolute;
+    position: fixed;
     top: 30px;
     right: 20px;
     padding: 10px;
@@ -9,11 +9,43 @@
     align-items: center;
     justify-content: center;
     border-radius: 15px;
-    background-color: #333;
+    background-color: rgb(39, 39, 39);
     color: rgba(255, 255, 255, 0.7);
+    opacity: 0.8;
+}
+
+.contribute-button > img {
+    width: 25px;
+    height: 25px;
+    margin-right: 10px;
 }
 
 .contribute-button:hover {
     background-color: black;
     color: white;
+}
+
+@media screen and (max-width: 1010px) {
+    .contribute-button {
+        position: fixed;
+        display: flex;
+        flex-direction: row-reverse;
+        top: auto;
+        bottom: 10px;
+        left: 20px;
+    }
+    
+    .contribute-button > img {
+        margin-right: 0px;
+        margin-left: 10px;
+    }
+
+    .hide-button {
+        transition: 4s;
+        transform: translateX(-190px);
+    }
+    
+    .hide-button:hover {
+        transform: translateX(0px);
+    }
 }

--- a/config.json
+++ b/config.json
@@ -12,7 +12,7 @@
     "evmchains": [
         {
             "ID": "C",
-            "NAME": "Fuji (C-Chain Testnet)",
+            "NAME": "Fuji (C-Chain)",
             "TOKEN": "AVAX",
             "RPC": "https://api.avax-test.network/ext/C/rpc",
             "CHAINID": 43113,
@@ -45,7 +45,7 @@
         },
         {
             "ID": "DFK",
-            "NAME": "DFK Chain Testnet",
+            "NAME": "DeFi Kingdoms Testnet",
             "TOKEN": "JEWEL",
             "RPC": "https://subnets.avax.network/defi-kingdoms/dfk-chain-testnet/rpc",
             "CHAINID": 335,

--- a/config.json
+++ b/config.json
@@ -12,7 +12,7 @@
     "evmchains": [
         {
             "ID": "C",
-            "NAME": "Fuji (C-Chain)",
+            "NAME": "Fuji (C-Chain Testnet)",
             "TOKEN": "AVAX",
             "RPC": "https://api.avax-test.network/ext/C/rpc",
             "CHAINID": 43113,
@@ -29,7 +29,7 @@
         },
         {
             "ID": "WAGMI",
-            "NAME": "WAGMI",
+            "NAME": "WAGMI Testnet",
             "TOKEN": "WGM",
             "RPC": "https://subnets.avax.network/wagmi/wagmi-chain-testnet/rpc",
             "CHAINID": 11111,
@@ -45,7 +45,7 @@
         },
         {
             "ID": "DFK",
-            "NAME": "Defi Kingdoms",
+            "NAME": "DFK Chain Testnet",
             "TOKEN": "JEWEL",
             "RPC": "https://subnets.avax.network/defi-kingdoms/dfk-chain-testnet/rpc",
             "CHAINID": 335,
@@ -61,7 +61,7 @@
         },
         {
             "ID": "DEXALOT",
-            "NAME": "Dexalot",
+            "NAME": "Dexalot Testnet",
             "TOKEN": "ALOT",
             "RPC": "https://subnets.avax.network/dexalot/testnet/rpc",
             "CHAINID": 432201,
@@ -77,7 +77,7 @@
         },
         {
             "ID": "SWIMMER",
-            "NAME": "Swimmer",
+            "NAME": "Swimmer Testnet",
             "TOKEN": "TUS",
             "RPC": "https://subnets.avax.network/swimmer/testnet/rpc",
             "CHAINID": 73771,
@@ -93,7 +93,7 @@
         },
         {
             "ID": "CASTLECRUSH",
-            "NAME": "Castle Crush",
+            "NAME": "Castle Crush Testnet",
             "TOKEN": "ACS",
             "RPC": "https://subnets.avax.network/castle-crush/testnet/rpc",
             "CHAINID": 31416,


### PR DESCRIPTION
- Changes query param from `chain` to `subnet`
- Changes chain names to include the `Testnet` suffix for consistency with the subnet explorer, and so that the "Add to Metamask" button also includes "Testnet" in the names so that chains don't get confused with their mainnet counterparts.
- Fixes mobile view UI
- Fixes background gradient during scroll