### PR TITLE
Legacy Tx Support

### DIFF
--- a/config.json
+++ b/config.json
@@ -83,6 +83,7 @@
             "CHAINID": 73771,
             "EXPLORER": "https://subnets.avax.network/swimmer/testnet/explorer",
             "IMAGE": "https://raw.githubusercontent.com/ava-labs/subnet-assets/main/chains/73771/chain-logo.png",
+            "LEGACY": true,
             "MAX_PRIORITY_FEE": "2000000000",
             "MAX_FEE": "100000000000",
             "DRIP_AMOUNT": 2000000000,

--- a/config.json
+++ b/config.json
@@ -83,9 +83,8 @@
             "CHAINID": 73771,
             "EXPLORER": "https://subnets.avax.network/swimmer/testnet/explorer",
             "IMAGE": "https://raw.githubusercontent.com/ava-labs/subnet-assets/main/chains/73771/chain-logo.png",
-            "LEGACY": true,
             "MAX_PRIORITY_FEE": "2000000000",
-            "MAX_FEE": "100000000000",
+            "MAX_FEE": "4200000000000",
             "DRIP_AMOUNT": 2000000000,
             "RATELIMIT": {
                 "MAX_LIMIT": 1,

--- a/vms/evm.ts
+++ b/vms/evm.ts
@@ -190,12 +190,12 @@ export default class EVM {
     }
 
     async getGasPrice(): Promise<number> {
-        return await this.web3.eth.getGasPrice()
+        return this.web3.eth.getGasPrice()
     }
 
     async getAdjustedGasPrice(): Promise<number> {
-        let gasPrice = await this.getGasPrice()
-        let adjustedGas = Math.floor(gasPrice * 1.25)
+        const gasPrice = await this.getGasPrice()
+        const adjustedGas = Math.floor(gasPrice * 1.25)
         return Math.min(adjustedGas, parseInt(this.MAX_FEE))
     }
 

--- a/vms/evmTypes.ts
+++ b/vms/evmTypes.ts
@@ -4,6 +4,7 @@ export type ConfigType = {
     ID: string,
     NAME: string,
     RPC: string,
+    LEGACY?: boolean,
     MAX_PRIORITY_FEE: string,
     MAX_FEE: string,
     DRIP_AMOUNT: number,

--- a/vms/evmTypes.ts
+++ b/vms/evmTypes.ts
@@ -4,7 +4,6 @@ export type ConfigType = {
     ID: string,
     NAME: string,
     RPC: string,
-    LEGACY?: boolean,
     MAX_PRIORITY_FEE: string,
     MAX_FEE: string,
     DRIP_AMOUNT: number,


### PR DESCRIPTION
* Added legacy tx support
* Can be configured in `config.json` file -

```json
"evmchains": [
  {
    "ID": "C",
    "LEGACY": true,
  }
]
```
EDIT: We do not need to provide `LEGACY` transaction type in the config file, it will identify on its own by seeing the `baseFee` parameter in the latest block.