### PR TITLE
Faucet stability during high usage

### DIFF
--- a/client/src/config.json
+++ b/client/src/config.json
@@ -2,7 +2,7 @@
     "banner": "/banner.webp",
     "apiBaseEndpointProduction": "/api/",
     "apiBaseEndpointDevelopment": "http://localhost:8000/api/",
-    "apiTimeout": 20000,
+    "apiTimeout": 40000,
     "CAPTCHA": {
         "siteKey": "6LerTgYgAAAAALa7WiJs3q0pM30PH6JH4oDi_DaK",
         "v2siteKey": "6LcPmIYgAAAAADKWHw28ercYsZV7QbDMz_SUeK-Q", 

--- a/config.json
+++ b/config.json
@@ -18,7 +18,7 @@
             "CHAINID": 43113,
             "EXPLORER": "https://testnet.snowtrace.io",
             "IMAGE": "https://glacier-api.avax.network/proxy/chain-assets/main/chains/43113/chain-logo.png",
-            "MAX_PRIORITY_FEE": "2500000000",
+            "MAX_PRIORITY_FEE": "10000000000",
             "MAX_FEE": "100000000000",
             "DRIP_AMOUNT": 2,
             "DECIMALS": 18,

--- a/vms/evm.ts
+++ b/vms/evm.ts
@@ -407,6 +407,16 @@ export default class EVM {
         }
     }
 
+    /*
+    * This function will trigger the re-calibration of nonce and balance.
+    * 1. Sets `waitingForRecalibration` to `true`.
+    * 2. Will not trigger re-calibration if:
+    *   a. any txs are pending
+    *   b. nonce or balance are already getting updated
+    *   c. any request is being queued up for execution
+    * 3. Checks at regular interval, when all the above conditions are suitable for re-calibration
+    * 4. Keeps any new incoming request into `waitArr` until nonce and balance are updated
+    */
     async recalibrateNonceAndBalance(): Promise<void> {
         this.waitingForRecalibration = true
 

--- a/vms/evm.ts
+++ b/vms/evm.ts
@@ -296,6 +296,7 @@ export default class EVM {
             this.nonce++
             this.executeQueue()
         } else {
+            this.queuingInProgress = false
             this.log.warn("Faucet balance too low!" + this.balance)
             this.hasError.set(req.receiver, "Faucet balance too low! Please try after sometime.")
         }

--- a/vms/utils.ts
+++ b/vms/utils.ts
@@ -7,3 +7,19 @@ export function calculateBaseUnit(amount: string, decimals: number): BN {
 
     return new BN(amount)
 }
+
+export const asyncCallWithTimeout = async (asyncPromise: Promise<void>, timeLimit: number, timeoutMessage: string) => {
+    let timeoutHandle: NodeJS.Timeout;
+
+    const timeoutPromise = new Promise((_resolve, reject) => {
+        timeoutHandle = setTimeout(
+            () => reject(new Error(timeoutMessage)),
+            timeLimit
+        );
+    });
+
+    return Promise.race([asyncPromise, timeoutPromise]).then(result => {
+        clearTimeout(timeoutHandle);
+        return result;
+    })
+}


### PR DESCRIPTION
This PR aims to increase stability during high usage.
- Increase priority fee per tx to 10 nAVAX
- Increase tx timeout to 40 seconds
- Should not accept any tx, if 15 txs are in processing (may not be broadcasted yet)
- Block requests during restart (to settle any pending txs initiated during shutdown)