### PR TITLE
feat: beam testnet config setup

### DIFF
--- a/config.json
+++ b/config.json
@@ -158,7 +158,7 @@
                 "MAX_LIMIT": 1,
                 "WINDOW_SIZE": 1440
             }
-        },
+        }
     ],
     "erc20tokens": [
         {

--- a/config.json
+++ b/config.json
@@ -141,7 +141,24 @@
                 "MAX_LIMIT": 1,
                 "WINDOW_SIZE": 1440
             }
-        }
+        },
+        {
+            "ID": "Beam",
+            "NAME": "Beam Testnet",
+            "TOKEN": "MC",
+            "RPC": "https://subnets.avax.network/beam/testnet/rpc",
+            "CHAINID": 13337,
+            "EXPLORER": "https://subnets-test.avax.network/beam",
+            "IMAGE": "https://glacier-api.avax.network/proxy/chain-assets/main/chains/13337/chain-logo.png",
+            "MAX_PRIORITY_FEE": "3000000000",
+            "MAX_FEE": "100000000000",
+            "DRIP_AMOUNT": 2,
+            "DECIMALS": 18,
+            "RATELIMIT": {
+                "MAX_LIMIT": 1,
+                "WINDOW_SIZE": 1440
+            }
+        },
     ],
     "erc20tokens": [
         {


### PR DESCRIPTION
Added config for Beam Subnet. The faucet wallet has been funded with 20k MC testnet tokens ([tx](https://subnets-test.avax.network/beam/tx/0x21f2ac703b90c34ab525755831d8e4814b78a02c6a528522b40b365e0f9eb6e3)).