### PR TITLE
Mainnet address tracker service

### DIFF
--- a/mainnetCheckService.ts
+++ b/mainnetCheckService.ts
@@ -1,0 +1,128 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb"
+import { DynamoDBDocumentClient, GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb"
+import { getNonce } from "./utils/mainnetBalanceCheck";
+
+const MAINNET_CHECK_TRACKER_TABLE = "mainnet_check_tracker";
+const MAX_ADDRESS_CHECK_COUNT = 3;
+
+type AddressStatus = {
+    checkCount: number,
+    lastUsedNonce: number,
+}
+
+export class MainnetCheckService {
+    private readonly documentClient: DynamoDBDocumentClient
+    private readonly RPC: string
+
+    constructor(rpc: string) {
+        const ddbClient = new DynamoDBClient({ region: 'us-east-1' })
+        this.documentClient = DynamoDBDocumentClient.from(ddbClient)
+        this.RPC = rpc
+    }
+
+    /**
+     * 1. Get check count and last used nonce (address status)
+     * 2. If checkCount < MAX_ADDRESS_CHECK_COUNT:
+     *    a. Asynchronously increment check count and update nonce
+     *    b. Return success
+     * 3. If checkCount == MAX_ADDRESS_CHECK_COUNT
+     *    a. Fetch current nonce from network, and last used nonce from DB
+     *    b. diff = currentNonce - lastUsedNonce
+     *    c. If diff > 0
+     *       i. checkCount = max(0, checkCount - diff)
+     *      ii. asynchronously update address status
+     *     iii. return success
+     *    d. If diff == 0
+     *       i. fail
+     */
+    async checkAddressValidity(address: string): Promise<boolean> {
+        let addressStatus = await this.getAddressStatus(address)
+        if (!addressStatus) {
+            // update address status
+            addressStatus = await this.updateAddressStatus(address)
+        }
+
+        if (addressStatus.checkCount < MAX_ADDRESS_CHECK_COUNT) {
+            this.updateAddressStatus(address, ++addressStatus.checkCount, addressStatus.lastUsedNonce)
+            return true
+        } else {
+            const currentNonce = await getNonce(this.RPC, address)
+            if (!currentNonce) {
+                throw "Error fetching nonce..."
+            }
+            const diff = currentNonce - addressStatus.lastUsedNonce
+            if (diff > 0) {
+                const updatedCheckCount = Math.max(0, addressStatus.checkCount - diff) + 1
+                this.updateAddressStatus(address, updatedCheckCount, currentNonce)
+                return true
+            } else {
+                return false
+            }
+        }
+    }
+
+    // Utility
+
+    async getAddressStatus(address: string): Promise<AddressStatus | undefined> {
+        const params = {
+            TableName: MAINNET_CHECK_TRACKER_TABLE,
+            Key: { address }
+        };
+        const command = new GetCommand(params);
+    
+        try {
+            const data = await this.documentClient.send(command);
+            if (!data.Item) {
+                return undefined;
+            }
+            
+            return {
+                checkCount: data.Item.checkCount,
+                lastUsedNonce: data.Item.lastUsedNonce,
+            }
+        } catch (error) {
+            console.error(JSON.stringify({
+                date: new Date(),
+                type: 'GetAddressStatusError',
+                item: error
+            }));
+        }
+    }
+
+    async updateAddressStatus(address: string, checkCount: number = 0, nonce?: number): Promise<AddressStatus> {
+        // if nonce is not provided, fetch from network
+        if (!nonce) {
+            const currentNonce = await getNonce(this.RPC, address)
+            if (!currentNonce) {
+                throw "Error fetching nonce..."
+            }
+            nonce = currentNonce
+        }
+
+        const params = {
+            TableName: MAINNET_CHECK_TRACKER_TABLE,
+            Item: {
+                address,
+                lastUsedNonce: nonce,
+                checkCount,
+            }
+        };
+    
+        const command = new PutCommand(params);
+    
+        try {
+            await this.documentClient.send(command);
+        } catch (error) {
+            console.error(JSON.stringify({
+                date: new Date(),
+                type: 'PuttingAddressTrackerError',
+                item: error
+            }));
+        }
+
+        return {
+            checkCount,
+            lastUsedNonce: nonce,
+        }
+    }
+}

--- a/server.ts
+++ b/server.ts
@@ -30,6 +30,7 @@ import {
     checkMainnetBalancePipeline,
     pipelineFailureMessage
 } from './utils/pipelineChecks'
+import { MainnetCheckService } from './mainnetCheckService'
 
 dotenv.config()
 
@@ -64,6 +65,7 @@ new RateLimiter(app, [
 })
 
 const couponService = new CouponService(couponConfig)
+const mainnetCheckService = new MainnetCheckService(MAINNET_BALANCE_CHECK_RPC)
 
 const captcha: VerifyCaptcha = new VerifyCaptcha(app, process.env.CAPTCHA_SECRET!, process.env.V2_CAPTCHA_SECRET!)
 
@@ -152,7 +154,7 @@ router.post('/sendToken', captcha.middleware, async (req: any, res: any) => {
     !pipelineValidity.isValid && couponCheckEnabled && await checkCouponPipeline(couponService, pipelineValidity, faucetConfigId, coupon)
     
     // don't check mainnet balance, if coupon is provided
-    !pipelineValidity.isValid && !coupon && mainnetCheckEnabled && await checkMainnetBalancePipeline(pipelineValidity, MAINNET_BALANCE_CHECK_RPC, address)
+    !pipelineValidity.isValid && !coupon && mainnetCheckEnabled && await checkMainnetBalancePipeline(mainnetCheckService, pipelineValidity, MAINNET_BALANCE_CHECK_RPC, address)
 
     if (
         (mainnetCheckEnabled || couponCheckEnabled) &&

--- a/utils/mainnetBalanceCheck.ts
+++ b/utils/mainnetBalanceCheck.ts
@@ -23,3 +23,22 @@ export async function checkMainnetBalance(rpc: string, address: string, threshol
     }
     return response
 }
+
+export async function getNonce(rpc: string, address: string): Promise<number | undefined> {
+    try {
+        const response = await axios.post<any, any>(rpc, {
+            jsonrpc: "2.0",
+            method: "eth_getTransactionCount",
+            params: [address, "latest"],
+            id: 1,
+        })
+        return parseInt(response.data.result)
+    } catch(err) {
+        console.error(JSON.stringify({
+            date: new Date(),
+            type: 'NonceCheckError',
+            item: err
+        }))
+        return undefined
+    }
+}

--- a/utils/pipelineChecks.ts
+++ b/utils/pipelineChecks.ts
@@ -57,12 +57,15 @@ export async function checkMainnetBalancePipeline(
 ) {
     const {isValid, balance} = await checkMainnetBalance(rpc, address)
     if (isValid) {
-        if (await mainnetCheckService.checkAddressValidity(address)) {
+        const mainnetAddressValidity = await mainnetCheckService.checkAddressValidity(address)
+        if (mainnetAddressValidity.isValid) {
             pipelineCheckValidity.isValid = true
             pipelineCheckValidity.checkPassedType = PIPELINE_CHECKS.MAINNET_BALANCE
             pipelineCheckValidity.mainnetBalance = balance
+        } else if (mainnetAddressValidity.internalError) {
+            pipelineCheckValidity.errorMessage = "Some internal error occurred during mainnet check. "
         } else {
-            pipelineCheckValidity.errorMessage = "Address has exhausted maximum balance checks! Please do some mainnet transactinos."
+            pipelineCheckValidity.errorMessage = "Address has exhausted maximum balance checks! Please do some mainnet transactions. "
         }
     } else {
         pipelineCheckValidity.errorMessage = "Mainnet balance check failed! " 


### PR DESCRIPTION
This pull request primarily focuses on the creation of a new `MainnetCheckService` class in the `mainnetCheckService.ts` file and the subsequent integration of this service into the existing codebase. The `MainnetCheckService` class is designed to interact with a DynamoDB database to track and manage the number of balance checks performed on a specific address. This is done to limit the number of balance checks to a maximum of three times, after which the user is required to perform a transaction on the mainnet to reset the check count. 

The main changes can be grouped into two categories:

Creation of the `MainnetCheckService`:

* [mainnetCheckService.ts](diffhunk://#diff-5046e0c224ada77758ce5fd923dc5d075d55bc1503828c57c4bf131a5277629cR1-R142): A new `MainnetCheckService` class was created. This class includes methods to interact with a DynamoDB database, such as `getAddressStatus` and `updateAddressStatus`, and a `checkAddressValidity` method to manage the balance check count for a specific address.

Integration of `MainnetCheckService` into the existing codebase:

* [server.ts](diffhunk://#diff-1ba718c1eb8aa39cd20c2562d92523068c734d75f54655e97d652b992d9b4259R33): Imported the `MainnetCheckService` and instantiated it. The `checkAddressValidity` method of the `MainnetCheckService` was then used in the `router.post('/sendToken',...)` method to replace the previous balance checking mechanism. [1](diffhunk://#diff-1ba718c1eb8aa39cd20c2562d92523068c734d75f54655e97d652b992d9b4259R33) [2](diffhunk://#diff-1ba718c1eb8aa39cd20c2562d92523068c734d75f54655e97d652b992d9b4259R68) [3](diffhunk://#diff-1ba718c1eb8aa39cd20c2562d92523068c734d75f54655e97d652b992d9b4259L155-R157)
* [utils/mainnetBalanceCheck.ts](diffhunk://#diff-53f32dc1b92ff692069b7ec56548243e0eb64e420a1d5f01634984a234094c05R26-R44): Added a new `getNonce` function to fetch the current nonce for a given address from the network.
* [utils/pipelineChecks.ts](diffhunk://#diff-467e210bb2224a12db4e4a3d48a0e423bb7a0a681e3468111b4e19d9a9ccf797R2): Modified the `checkMainnetBalancePipeline` function to use the `MainnetCheckService` for balance checking and to handle potential internal errors. [1](diffhunk://#diff-467e210bb2224a12db4e4a3d48a0e423bb7a0a681e3468111b4e19d9a9ccf797R2) [2](diffhunk://#diff-467e210bb2224a12db4e4a3d48a0e423bb7a0a681e3468111b4e19d9a9ccf797L51-R69)