### PR TITLE
Update max fee for NUM's testnet

### DIFF
--- a/config.json
+++ b/config.json
@@ -95,7 +95,7 @@
             "EXPLORER": "https://testnet.num.network",
             "IMAGE": "https://i.imgur.com/6ZG2tIW.png",
             "MAX_PRIORITY_FEE": "2000000000",
-            "MAX_FEE": "100000000000",
+            "MAX_FEE": "750000000000",
             "DRIP_AMOUNT": 2,
             "RATELIMIT": {
                 "MAX_LIMIT": 1,


### PR DESCRIPTION
Update max fee for NUM's testnet to 750 GWEI (750,000,000,000)