### PR TITLE
Modify native token name on Eclipse Testnet

### DIFF
--- a/config.json
+++ b/config.json
@@ -221,7 +221,7 @@
         {
             "ID": "ECLIPSET",
             "NAME": "Eclipse Testnet",
-            "TOKEN": "ECLP",
+            "TOKEN": "ECLPS",
             "RPC": "https://subnets.avax.network/eclipsecha/testnet/rpc",
             "CHAINID": 555666,
             "EXPLORER": "https://subnets-test.avax.network/eclipsecha",


### PR DESCRIPTION
I want to modify the native token name from ECLP to ECLPS(on our Eclipse Testnet).
Please help to review this and let me know if there are any issues.