### PR TITLE
Change ID of PLYRT to PLYR

### DIFF
--- a/config.json
+++ b/config.json
@@ -251,6 +251,23 @@
                 "MAX_LIMIT": 2,
                 "WINDOW_SIZE": 1440
             }
+        },
+		{
+            "ID": "PLYRT",
+            "NAME": "PLYR TAU Testnet",
+            "TOKEN": "PLYR",
+            "RPC": "https://subnets.avax.network/plyr/testnet/rpc",
+            "CHAINID": 62831,
+            "EXPLORER": "https://subnets-test.avax.network/plyr",
+            "IMAGE": "https://plyr.network/plyr_logo.png",
+            "MAX_PRIORITY_FEE": "100000000000",
+            "MAX_FEE": "100000000000",
+            "DRIP_AMOUNT": 1,
+            "DECIMALS": 18,
+            "RATELIMIT": {
+                "MAX_LIMIT": 1,
+                "WINDOW_SIZE": 1440
+            }
         }
     ],
     "erc20tokens": [

--- a/config.json
+++ b/config.json
@@ -262,7 +262,7 @@
             "IMAGE": "https://plyr.network/plyr_logo.png",
             "MAX_PRIORITY_FEE": "100000000000",
             "MAX_FEE": "100000000000",
-            "DRIP_AMOUNT": 1,
+            "DRIP_AMOUNT": 5,
             "DECIMALS": 18,
             "RATELIMIT": {
                 "MAX_LIMIT": 1,

--- a/config.json
+++ b/config.json
@@ -253,7 +253,7 @@
             }
         },
 		{
-            "ID": "PLYRT",
+            "ID": "PLYR",
             "NAME": "PLYR TAU Testnet",
             "TOKEN": "PLYR",
             "RPC": "https://subnets.avax.network/plyr/testnet/rpc",


### PR DESCRIPTION
Really sorry about the ID. We didn't notice that it gonna be used for query string ?subnet=plyrt

we just want to use https://core.app/tools/testnet-faucet?subnet=plyr (not plyrt)