### PR TITLE
common token disbursal rate limit

### DIFF
--- a/CouponService/couponService.ts
+++ b/CouponService/couponService.ts
@@ -13,6 +13,7 @@ export type Coupon = {
     reset: boolean,
     skipIpRateLimit?: boolean,
     skipWalletRateLimit?: boolean,
+    skipCommonTokenDisbursalRateLimit?: boolean,
 }
 
 type CouponConfig = {

--- a/config.json
+++ b/config.json
@@ -36,6 +36,10 @@
             "RATELIMIT": {
                 "MAX_LIMIT": 1,
                 "WINDOW_SIZE": 1440
+            },
+            "COMMON_TOKEN_DISBURSAL_RL": {
+                "MAX_LIMIT": 20,
+                "WINDOW_SIZE": 60
             }
         },
         {

--- a/middlewares/rateLimiter.ts
+++ b/middlewares/rateLimiter.ts
@@ -5,15 +5,21 @@ import { CouponService } from '../CouponService/couponService'
 
 export class RateLimiter {
     PATH: string
-    type: 'ip' | 'wallet' | 'global'
+    type: 'ip' | 'wallet' | 'global' | 'common_token_disbursal'
 
     constructor(
         app: any,
         configs: RateLimiterConfig[],
-        type: 'ip' | 'wallet' | 'global',
+        type: 'ip' | 'wallet' | 'global' | 'common_token_disbursal',
         couponService: CouponService,
         keyGenerator?: any,
     ) {
+        if (configs.length === 0) {
+            this.PATH = '/api/sendToken'
+            this.type = 'common_token_disbursal'
+            return
+        }
+
         this.PATH = configs[0].RATELIMIT.PATH || '/api/sendToken'
         this.type = type
 
@@ -42,6 +48,8 @@ export class RateLimiter {
                 if (this.type === 'ip' && coupon && coupon.skipIpRateLimit) {
                     return next()
                 } else if (this.type === 'wallet' && coupon && coupon.skipWalletRateLimit) {
+                    return next()
+                } else if (this.type === 'common_token_disbursal' && coupon && coupon.skipCommonTokenDisbursalRateLimit) {
                     return next()
                 }
             }

--- a/types.ts
+++ b/types.ts
@@ -41,6 +41,10 @@ export type ChainType = {
     RATELIMIT: {
         WINDOW_SIZE: number,
         MAX_LIMIT: number
+    },
+    COMMON_TOKEN_DISBURSAL_RL?: {
+        WINDOW_SIZE: number,
+        MAX_LIMIT: number
     }
 }
 
@@ -54,6 +58,10 @@ export type ERC20Type = {
     DRIP_AMOUNT: number,
     DECIMALS: number,
     RATELIMIT: {
+        WINDOW_SIZE: number,
+        MAX_LIMIT: number
+    },
+    COMMON_TOKEN_DISBURSAL_RL?: {
         WINDOW_SIZE: number,
         MAX_LIMIT: number
     },


### PR DESCRIPTION
Set up a configuration for a global faucet rate limit on total token disbursals that can occur within a particular window.
eg:
```
20 requests every 60 minutes
```
If this rate limit is reached, no one (even the first-time users) will be able to request tokens unless the 60-minute window is over.

