### PR TITLE
Update global faucet rate limit to 40 requests/hour rather than the c…

### DIFF
--- a/config.json
+++ b/config.json
@@ -38,7 +38,7 @@
                 "WINDOW_SIZE": 1440
             },
             "COMMON_TOKEN_DISBURSAL_RL": {
-                "MAX_LIMIT": 20,
+                "MAX_LIMIT": 40,
                 "WINDOW_SIZE": 60
             }
         },


### PR DESCRIPTION
…urrent 20, after Core got blocked.

https://app.datadoghq.com/s/zk39ngefvty1feg8/8xx-mzs-tqe

shows that we have been blocking faucet requests.  Today (2025-08-26) Core reported the blockage (for the first time as far as I know). 

We have been blocking more than 20 requests/hour but if something (e.g Core) keeps retrying on failure, 20 additional requests may be enough to clear all of them.